### PR TITLE
Only attempting init of RST pin if it's actually used

### DIFF
--- a/src/hal/hal.c
+++ b/src/hal/hal.c
@@ -34,7 +34,9 @@ static void hal_io_init () {
     gpio_config_t io_conf;
     io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
     io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pin_bit_mask = (1<<lmic_pins.nss) | (1<<lmic_pins.rst);
+    io_conf.pin_bit_mask = 1<<lmic_pins.nss;
+    if(lmic_pins.rst != LMIC_UNUSED_PIN) 
+        io_conf.pin_bit_mask |= 1<<lmic_pins.rst;
     io_conf.pull_down_en = 0;
     io_conf.pull_up_en = 0;
     gpio_config(&io_conf);

--- a/src/hal/hal.c
+++ b/src/hal/hal.c
@@ -35,8 +35,9 @@ static void hal_io_init () {
     io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
     io_conf.mode = GPIO_MODE_OUTPUT;
     io_conf.pin_bit_mask = 1<<lmic_pins.nss;
-    if(lmic_pins.rst != LMIC_UNUSED_PIN) 
+    if(lmic_pins.rst != LMIC_UNUSED_PIN) {
         io_conf.pin_bit_mask |= 1<<lmic_pins.rst;
+    }
     io_conf.pull_down_en = 0;
     io_conf.pull_up_en = 0;
     gpio_config(&io_conf);


### PR DESCRIPTION
Otherwise, `esp-idf` 3.3 generates a GPIO_PIN mask error

Addresses #3 , however I have only tested that the device starts up without error - not whether the radio is fully functional